### PR TITLE
remove and abstract Puppet dependency; manually require the gem you want to use

### DIFF
--- a/bin/dropsonde
+++ b/bin/dropsonde
@@ -72,7 +72,7 @@ class Dropsonde
     c.flag [:endpoint]
 
     c.desc 'Telemetry port'
-    c.flag [:port]
+    c.flag [:port], :type => Integer
 
     c.action do |global, options, args|
       @cache.autoupdate

--- a/bin/dropsonde
+++ b/bin/dropsonde
@@ -69,14 +69,14 @@ class Dropsonde
   desc 'Submit a telemetry report'
   command :submit do |c|
     c.desc 'Telemetry endpoint'
-    c.flag [:endpoint], :default_value => 'https://updates.puppet.com'
+    c.flag [:endpoint]
 
     c.desc 'Telemetry port'
-    c.flag [:port], :default_value => 443, :type => Integer
+    c.flag [:port]
 
     c.action do |global, options, args|
       @cache.autoupdate
-      Dropsonde.submit_report(options[:endpoint], options[:port])
+      Dropsonde.submit_report(options)
     end
   end
 

--- a/dropsonde.gemspec
+++ b/dropsonde.gemspec
@@ -20,7 +20,6 @@ Gem::Specification.new do |s|
   s.add_dependency      "gli"
   s.add_dependency      "httpclient"
   s.add_dependency      "little-plugger"
-  s.add_dependency      "puppet"
   s.add_dependency      "puppet_forge"
   s.add_dependency      "semantic_puppet"
   s.add_dependency      "inifile"
@@ -30,6 +29,11 @@ Gem::Specification.new do |s|
   Dropsonde is a simple telemetry probe designed to run as a regular cron job. It
   will gather metrics defined by self-contained plugins that each defines its own
   partial schema and then gathers the data to meet that schema.
+  desc
+
+  s.post_install_message = <<~desc
+  For portability reasons, this gem no longer depends on Puppet. You will need to
+  install either Puppet or OpenVox gems manually.
   desc
 
 end

--- a/lib/dropsonde.rb
+++ b/lib/dropsonde.rb
@@ -8,7 +8,7 @@ require 'inifile'
 begin
   require 'puppet'
 rescue LoadError
-  fail "Please install either Puppet or OpenVox gem to use this tool."
+  raise 'Please install either Puppet or OpenVox gem to use this tool.'
 end
 
 # This class handles caching module process, generate reports,
@@ -91,7 +91,6 @@ class Dropsonde
       require 'dropsonde/submitter/dujour'
       Dropsonde::Submitter::Dujour.submit_report(options)
     end
-
   end
 
   def self.generate_example(size, filename)

--- a/lib/dropsonde.rb
+++ b/lib/dropsonde.rb
@@ -4,7 +4,12 @@ require 'json'
 require 'httpclient'
 require 'puppetdb'
 require 'inifile'
-require 'puppet'
+
+begin
+  require 'puppet'
+rescue LoadError
+  fail "Please install either Puppet or OpenVox gem to use this tool."
+end
 
 # This class handles caching module process, generate reports,
 # fetchs all plugins defined in lib/dropsonde/metrics and also
@@ -14,6 +19,9 @@ class Dropsonde
   require 'dropsonde/metrics'
   require 'dropsonde/monkeypatches'
   require 'dropsonde/version'
+
+  # This class abstracts the endpoint we submit to.
+  class Dropsonde::Submitter; end
 
   def self.puppet_settings_overrides
     overrides = []
@@ -75,34 +83,15 @@ class Dropsonde
     end
   end
 
-  def self.submit_report(endpoint, port)
-    client = HTTPClient.new
-
-    # The httpclient gem ships with some expired CA certificates.
-    # This causes us to load the certs shipped with whatever
-    # Ruby is used to execute this gem's commands, which are generally
-    # more up-to-date, especially if using puppet-agent's Ruby.
-    #
-    # Note that this is no-op with Windows system Ruby.
-    client.ssl_config.set_default_paths
-
-    result = client.post("#{endpoint}:#{port}",
-                         header: { 'Content-Type' => 'application/json' },
-                         body: Dropsonde::Metrics.new.report.to_json)
-
-    if result.status == 200
-      data = JSON.parse(result.body)
-      if data['newer']
-        puts 'A newer version of the telemetry client is available:'
-        puts "  -- #{data['link']}"
-      else
-        puts data['message']
-      end
+  def self.submit_report(options)
+    if Puppet.respond_to?(:implementation) && Puppet.implementation == 'openvox'
+      require 'dropsonde/submitter/open_telemetry'
+      Dropsonde::Submitter::OpenTelemetry.submit_report(options)
     else
-      puts 'Failed to submit report'
-      puts JSON.pretty_generate(result.body) if Dropsonde.settings[:verbose]
-      exit 1
+      require 'dropsonde/submitter/dujour'
+      Dropsonde::Submitter::Dujour.submit_report(options)
     end
+
   end
 
   def self.generate_example(size, filename)

--- a/lib/dropsonde/submitter/dujour.rb
+++ b/lib/dropsonde/submitter/dujour.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # This uses Puppet's standard Dujour telemetry endpoint.
 # It currently expects a report formatted precisely to meet Dujour's odd schema.
 # At some point, we'll define our own report format and this submitter will
@@ -5,7 +7,6 @@
 #
 # This is currently the only operational submitter.
 class Dropsonde::Submitter::Dujour
-
   def self.submit_report(options)
     client = HTTPClient.new
 
@@ -38,5 +39,4 @@ class Dropsonde::Submitter::Dujour
       exit 1
     end
   end
-
 end

--- a/lib/dropsonde/submitter/dujour.rb
+++ b/lib/dropsonde/submitter/dujour.rb
@@ -1,0 +1,42 @@
+# This uses Puppet's standard Dujour telemetry endpoint.
+# It currently expects a report formatted precisely to meet Dujour's odd schema.
+# At some point, we'll define our own report format and this submitter will
+# transform it to meet the expected schema.
+#
+# This is currently the only operational submitter.
+class Dropsonde::Submitter::Dujour
+
+  def self.submit_report(options)
+    client = HTTPClient.new
+
+    endpoint = options[:endpoint] || Dropsonde.settings[:endpoint] || 'https://updates.puppet.com'
+    port     = options[:port]     || Dropsonde.settings[:port]     || 443
+
+    # The httpclient gem ships with some expired CA certificates.
+    # This causes us to load the certs shipped with whatever
+    # Ruby is used to execute this gem's commands, which are generally
+    # more up-to-date, especially if using puppet-agent's Ruby.
+    #
+    # Note that this is no-op with Windows system Ruby.
+    client.ssl_config.set_default_paths
+
+    result = client.post("#{endpoint}:#{port}",
+                         header: { 'Content-Type' => 'application/json' },
+                         body: Dropsonde::Metrics.new.report.to_json)
+
+    if result.status == 200
+      data = JSON.parse(result.body)
+      if data['newer']
+        puts 'A newer version of the telemetry client is available:'
+        puts "  -- #{data['link']}"
+      else
+        puts data['message']
+      end
+    else
+      puts 'Failed to submit report'
+      puts JSON.pretty_generate(result.body) if Dropsonde.settings[:verbose]
+      exit 1
+    end
+  end
+
+end

--- a/lib/dropsonde/submitter/open_telemetry.rb
+++ b/lib/dropsonde/submitter/open_telemetry.rb
@@ -1,10 +1,10 @@
+# frozen_string_literal: true
+
 # This currently doesn't actually exist.
 # It's just a placeholder for someday when it does exist!
 class Dropsonde::Submitter::OpenTelemetry
-
   def self.submit_report(options)
-    puts "When Vox Pupuli has its own telemetry server, this will post there."
+    puts 'When Vox Pupuli has its own telemetry server, this will post there.'
     puts options.inspect
   end
-
 end

--- a/lib/dropsonde/submitter/open_telemetry.rb
+++ b/lib/dropsonde/submitter/open_telemetry.rb
@@ -1,0 +1,10 @@
+# This currently doesn't actually exist.
+# It's just a placeholder for someday when it does exist!
+class Dropsonde::Submitter::OpenTelemetry
+
+  def self.submit_report(options)
+    puts "When Vox Pupuli has its own telemetry server, this will post there."
+    puts options.inspect
+  end
+
+end

--- a/spec/unit/dropsonde_spec.rb
+++ b/spec/unit/dropsonde_spec.rb
@@ -94,7 +94,7 @@ RSpec.describe Dropsonde do
         body: telemetry_report,
       ).and_return(response1)
 
-      expect { described_class.submit_report('example.com', 1234) }.not_to raise_error
+      expect { described_class.submit_report({:endpoint => 'example.com', :port => 1234}) }.not_to raise_error
     end
 
     it 'submit_report without errors' do
@@ -108,7 +108,7 @@ RSpec.describe Dropsonde do
         body: telemetry_report,
       ).and_return(response2)
 
-      expect { described_class.submit_report('example.com', 1234) }.not_to raise_error
+      expect { described_class.submit_report({:endpoint => 'example.com', :port => 1234}) }.not_to raise_error
     end
 
     it 'submit_report and receive response 500 - internal server error' do
@@ -123,7 +123,7 @@ RSpec.describe Dropsonde do
       ).and_return(response3)
 
       begin
-        described_class.submit_report('example.com', 1234)
+        described_class.submit_report({:endpoint => 'example.com', :port => 1234})
       rescue SystemExit => e
         expect(e.status).to eq(1)
       end

--- a/spec/unit/dropsonde_spec.rb
+++ b/spec/unit/dropsonde_spec.rb
@@ -94,7 +94,7 @@ RSpec.describe Dropsonde do
         body: telemetry_report,
       ).and_return(response1)
 
-      expect { described_class.submit_report({:endpoint => 'example.com', :port => 1234}) }.not_to raise_error
+      expect { described_class.submit_report({ endpoint: 'example.com', port: 1234 }) }.not_to raise_error
     end
 
     it 'submit_report without errors' do
@@ -108,7 +108,7 @@ RSpec.describe Dropsonde do
         body: telemetry_report,
       ).and_return(response2)
 
-      expect { described_class.submit_report({:endpoint => 'example.com', :port => 1234}) }.not_to raise_error
+      expect { described_class.submit_report({ endpoint: 'example.com', port: 1234 }) }.not_to raise_error
     end
 
     it 'submit_report and receive response 500 - internal server error' do
@@ -123,7 +123,7 @@ RSpec.describe Dropsonde do
       ).and_return(response3)
 
       begin
-        described_class.submit_report({:endpoint => 'example.com', :port => 1234})
+        described_class.submit_report({ endpoint: 'example.com', port: 1234 })
       rescue SystemExit => e
         expect(e.status).to eq(1)
       end


### PR DESCRIPTION
This removes the hard dependency on the `puppet` gem. It will simply use whichever gem you have installed that provides the `puppet` namespace.

Con: this means that it will no longer automatically install all of its
     dependencies. You must do it yourself.

It also sets the stage for abstracting out the telemetry backend. If `Puppet.implementation` returns 'openvox' then it will load an alternate backend, which is currently a noop because we don't have one stood up yet.

Warning: this will silently break both our and Perforce's server packaging job. An appropriate implementation gem must be added to https://github.com/OpenVoxProject/openvox-server/blob/main/resources/ext/build-scripts/dropsonde-gem.txt

(or we can do a better packaging job, lol)