### PR TITLE
fix broken acceptance test

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,8 @@
 ---
 require: rubocop-rspec
 inherit_from: .rubocop_todo.yml
+plugins:
+  - rubocop-capybara
 AllCops:
   TargetRubyVersion: '2.5'
   Include:
@@ -65,6 +67,12 @@ Style/TrailingCommaInArguments:
 Style/SymbolArray:
   Description: Using percent style obscures symbolic intent of array's contents.
   EnforcedStyle: brackets
+Style/RedundantReturn:
+  Description: Clarity around what is being returned is often useful.
+  Enabled: false
+Layout/FirstArrayElementIndentation:
+  Description: Deep indentation becomes unreadable.
+  EnforcedStyle: consistent
 Layout/EndOfLine:
   Enabled: false
 Style/CollectionMethods:
@@ -167,7 +175,7 @@ Style/HashTransformKeys:
 Style/HashTransformValues:
   Enabled: true
 
-RSpec/FactoryBot/CreateList:
+FactoryBot/CreateList:
   Description: "errors nastily on rubocop-rspec 1.42.0 and is not relevant to us anyways"
   Enabled: false
 

--- a/lib/dropsonde/metrics.rb
+++ b/lib/dropsonde/metrics.rb
@@ -52,7 +52,7 @@ class Dropsonde::Metrics
 
   def schema
     schema = skeleton_schema
-    Dropsonde::Metrics.plugins.each do |_name, plugin|
+    Dropsonde::Metrics.plugins.each_value do |plugin|
       schema.concat(sanity_check_schema(plugin))
     end
     check_for_duplicates(schema)
@@ -62,7 +62,7 @@ class Dropsonde::Metrics
   def preview(puppetdb_session = nil)
     str = "                      Puppet Telemetry Report Preview\n"
     str += "                      ===============================\n\n"
-    Dropsonde::Metrics.plugins.each do |_name, plugin|
+    Dropsonde::Metrics.plugins.each_value do |plugin|
       schema = plugin.schema
 
       plugin.setup if plugin.respond_to? :setup
@@ -91,7 +91,7 @@ class Dropsonde::Metrics
 
   def report(puppetdb_session = nil)
     snapshots = {}
-    Dropsonde::Metrics.plugins.each do |_name, plugin|
+    Dropsonde::Metrics.plugins.each_value do |plugin|
       plugin.setup
       sanity_check_data(plugin, plugin.run(puppetdb_session)).each do |row|
         snapshots[row.keys.first] = {
@@ -115,7 +115,7 @@ class Dropsonde::Metrics
     results[:ip]         = IPAddr.new(rand(2**32), Socket::AF_INET)
     results.delete(:'self-service-analytics')
 
-    Dropsonde::Metrics.plugins.each do |_name, plugin|
+    Dropsonde::Metrics.plugins.each_value do |plugin|
       sanity_check_data(plugin, plugin.example).each do |row|
         results.merge!(row)
       end

--- a/spec/acceptance/dropsonde_spec.rb
+++ b/spec/acceptance/dropsonde_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe 'Dropsonde Acceptance: Basic' do
   end
 
   context 'when update' do
-    it 'works' do
+    it 'caches Forge modules properly' do
       Dropsonde::Cache.new('foo', 7, true)
     end
   end
@@ -31,19 +31,19 @@ RSpec.describe 'Dropsonde Acceptance: Basic' do
       Dropsonde.settings = { enable: %w[dependencies modules] }
       allow(puppetdb_session.puppet_db).to receive(:request).with('', 'resources[type, title] { type = "Class" }').and_return(
         OpenStruct.new(data: [
-                         { 'type' => 'Class', 'title' => 'Mysql::Params' },
-                         { 'type' => 'Class', 'title' => 'Mysql::Server::Account_security' },
-                         { 'type' => 'Class', 'title' => 'Role::Database_server' },
-                         { 'type' => 'Class', 'title' => 'Mysql::Server::Install' },
-                         { 'type' => 'Class', 'title' => 'Mysql::Server::Providers' },
-                         { 'type' => 'Class', 'title' => 'My_private_module' },
-                         { 'type' => 'Class', 'title' => 'Mysql::Server::Managed_dirs' },
-                         { 'type' => 'Class', 'title' => 'Profile::Scr_mysql' },
-                         { 'type' => 'Class', 'title' => 'Mysql::Server' },
-                         { 'type' => 'Class', 'title' => 'Profile::Base' },
-                         { 'type' => 'Class', 'title' => 'Mysql::Server::Config' },
-                         { 'type' => 'Class', 'title' => 'Mysql::Server::Service' },
-                       ]),
+          { 'type' => 'Class', 'title' => 'Mysql::Params' },
+          { 'type' => 'Class', 'title' => 'Mysql::Server::Account_security' },
+          { 'type' => 'Class', 'title' => 'Role::Database_server' },
+          { 'type' => 'Class', 'title' => 'Mysql::Server::Install' },
+          { 'type' => 'Class', 'title' => 'Mysql::Server::Providers' },
+          { 'type' => 'Class', 'title' => 'My_private_module' },
+          { 'type' => 'Class', 'title' => 'Mysql::Server::Managed_dirs' },
+          { 'type' => 'Class', 'title' => 'Profile::Scr_mysql' },
+          { 'type' => 'Class', 'title' => 'Mysql::Server' },
+          { 'type' => 'Class', 'title' => 'Profile::Base' },
+          { 'type' => 'Class', 'title' => 'Mysql::Server::Config' },
+          { 'type' => 'Class', 'title' => 'Mysql::Server::Service' },
+        ]),
       )
       plugins = Dropsonde::Metrics.new.report(puppetdb_session)[:'self-service-analytics'][:snapshots]
       modules = plugins[:modules]['value'].map { |mod| mod[:name] }.sort

--- a/spec/spec_helper_acceptance_local.rb
+++ b/spec/spec_helper_acceptance_local.rb
@@ -41,63 +41,74 @@ class CISest
   end
 end
 
+class EnvList
+  def list
+    [OpenStruct.new(name: 'production')]
+  end
+
+  def get(env)
+    raise 'Unexpected environment' unless [:production, 'production'].include? env
+
+    OpenStruct.new(modules: [
+       OpenStruct.new(
+         name: 'mysql',
+         slug: 'puppetlabs-mysql',
+         version: '11.0.1',
+         forge_module?: true,
+         dependencies: [
+           { name: 'puppetlabs/stdlib', version_requirement: '>= 3.2.0 < 8.0.0' },
+           { name: 'puppetlabs/resource_api', version_requirement: '>= 1.0.0 < 2.0.0' },
+         ],
+         all_manifests: [],
+       ),
+       OpenStruct.new(
+         name: 'apache',
+         slug: 'puppetlabs-apache',
+         version: '6.0.0',
+         forge_module?: true,
+         dependencies: [
+           { name: 'puppetlabs/stdlib', version_requirement: '>= 4.13.1 < 8.0.0' },
+           { name: 'puppetlabs/concat', version_requirement: '>= 2.2.1 < 8.0.0' },
+         ],
+         all_manifests: [],
+       ),
+       OpenStruct.new(
+         name: 'concat',
+         slug: 'puppetlabs-concat',
+         version: '7.0.1',
+         forge_module?: true,
+         dependencies: [{ name: 'puppetlabs/stdlib', version_requirement: '>= 4.13.1 < 8.0.0' }],
+         all_manifests: [],
+       ),
+       OpenStruct.new(
+         name: 'stdlib',
+         slug: 'puppetlabs-stdlib',
+         version: '7.0.1',
+         forge_module?: true,
+         dependencies: [],
+         all_manifests: ['/etc/puppetlabs/code/environments/production/modules/stdlib/manifests/init.pp'],
+       ),
+       OpenStruct.new(
+         name: 'my_private_module',
+         slug: 'my_private_module',
+         version: '4.1.0',
+         forge_module?: false,
+         dependencies: [
+           { name: 'private_module_1', version_requirement: '>= 4.24.0 < 8.0.0' },
+           { name: 'private_module_2', version_requirement: '>= 4.4.1 < 9.0.0' },
+           { name: 'puppetlabs/powershell', version_requirement: '>= 2.1.4 < 6.0.0' },
+           { name: 'puppetlabs/reboot', version_requirement: '>=2.0.0 < 5.0.0' },
+         ],
+         all_manifests: [],
+       ),
+     ])
+  end
+end
+
 RSpec.configure do |c|
   c.formatter = :documentation
   c.before :each do
-    allow(Puppet).to receive(:lookup).with(:environments).at_least(2).and_return(OpenStruct.new(list: [OpenStruct.new(name: 'production')], get: 'production'))
-    allow(Puppet.lookup(:environments)).to receive(:get).at_least(2).and_return(OpenStruct.new(modules: [
-                                                                                                 OpenStruct.new(
-                                                                                                   name: 'mysql',
-                                                                                                   slug: 'puppetlabs-mysql',
-                                                                                                   version: '11.0.1',
-                                                                                                   forge_module?: true,
-                                                                                                   dependencies: [
-                                                                                                     { name: 'puppetlabs/stdlib', version_requirement: '>= 3.2.0 < 8.0.0' },
-                                                                                                     { name: 'puppetlabs/resource_api', version_requirement: '>= 1.0.0 < 2.0.0' },
-                                                                                                   ],
-                                                                                                   all_manifests: [],
-                                                                                                 ),
-                                                                                                 OpenStruct.new(
-                                                                                                   name: 'apache',
-                                                                                                   slug: 'puppetlabs-apache',
-                                                                                                   version: '6.0.0',
-                                                                                                   forge_module?: true,
-                                                                                                   dependencies: [
-                                                                                                     { name: 'puppetlabs/stdlib', version_requirement: '>= 4.13.1 < 8.0.0' },
-                                                                                                     { name: 'puppetlabs/concat', version_requirement: '>= 2.2.1 < 8.0.0' },
-                                                                                                   ],
-                                                                                                   all_manifests: [],
-                                                                                                 ),
-                                                                                                 OpenStruct.new(
-                                                                                                   name: 'concat',
-                                                                                                   slug: 'puppetlabs-concat',
-                                                                                                   version: '7.0.1',
-                                                                                                   forge_module?: true,
-                                                                                                   dependencies: [{ name: 'puppetlabs/stdlib', version_requirement: '>= 4.13.1 < 8.0.0' }],
-                                                                                                   all_manifests: [],
-                                                                                                 ),
-                                                                                                 OpenStruct.new(
-                                                                                                   name: 'stdlib',
-                                                                                                   slug: 'puppetlabs-stdlib',
-                                                                                                   version: '7.0.1',
-                                                                                                   forge_module?: true,
-                                                                                                   dependencies: [],
-                                                                                                   all_manifests: ['/etc/puppetlabs/code/environments/production/modules/stdlib/manifests/init.pp'],
-                                                                                                 ),
-                                                                                                 OpenStruct.new(
-                                                                                                   name: 'my_private_module',
-                                                                                                   slug: 'my_private_module',
-                                                                                                   version: '4.1.0',
-                                                                                                   forge_module?: false,
-                                                                                                   dependencies: [
-                                                                                                     { name: 'private_module_1', version_requirement: '>= 4.24.0 < 8.0.0' },
-                                                                                                     { name: 'private_module_2', version_requirement: '>= 4.4.1 < 9.0.0' },
-                                                                                                     { name: 'puppetlabs/powershell', version_requirement: '>= 2.1.4 < 6.0.0' },
-                                                                                                     { name: 'puppetlabs/reboot', version_requirement: '>=2.0.0 < 5.0.0' },
-                                                                                                   ],
-                                                                                                   all_manifests: [],
-                                                                                                 ),
-                                                                                               ]))
+    allow(Puppet).to receive(:lookup).with(:environments).at_least(2).and_return(EnvList.new)
     allow(Puppet::InfoService::ClassInformationService).to receive(:new).and_return(CISest.new)
   end
 end

--- a/spec/spec_helper_acceptance_local.rb
+++ b/spec/spec_helper_acceptance_local.rb
@@ -50,58 +50,58 @@ class EnvList
     raise 'Unexpected environment' unless [:production, 'production'].include? env
 
     OpenStruct.new(modules: [
-       OpenStruct.new(
-         name: 'mysql',
-         slug: 'puppetlabs-mysql',
-         version: '11.0.1',
-         forge_module?: true,
-         dependencies: [
-           { name: 'puppetlabs/stdlib', version_requirement: '>= 3.2.0 < 8.0.0' },
-           { name: 'puppetlabs/resource_api', version_requirement: '>= 1.0.0 < 2.0.0' },
-         ],
-         all_manifests: [],
-       ),
-       OpenStruct.new(
-         name: 'apache',
-         slug: 'puppetlabs-apache',
-         version: '6.0.0',
-         forge_module?: true,
-         dependencies: [
-           { name: 'puppetlabs/stdlib', version_requirement: '>= 4.13.1 < 8.0.0' },
-           { name: 'puppetlabs/concat', version_requirement: '>= 2.2.1 < 8.0.0' },
-         ],
-         all_manifests: [],
-       ),
-       OpenStruct.new(
-         name: 'concat',
-         slug: 'puppetlabs-concat',
-         version: '7.0.1',
-         forge_module?: true,
-         dependencies: [{ name: 'puppetlabs/stdlib', version_requirement: '>= 4.13.1 < 8.0.0' }],
-         all_manifests: [],
-       ),
-       OpenStruct.new(
-         name: 'stdlib',
-         slug: 'puppetlabs-stdlib',
-         version: '7.0.1',
-         forge_module?: true,
-         dependencies: [],
-         all_manifests: ['/etc/puppetlabs/code/environments/production/modules/stdlib/manifests/init.pp'],
-       ),
-       OpenStruct.new(
-         name: 'my_private_module',
-         slug: 'my_private_module',
-         version: '4.1.0',
-         forge_module?: false,
-         dependencies: [
-           { name: 'private_module_1', version_requirement: '>= 4.24.0 < 8.0.0' },
-           { name: 'private_module_2', version_requirement: '>= 4.4.1 < 9.0.0' },
-           { name: 'puppetlabs/powershell', version_requirement: '>= 2.1.4 < 6.0.0' },
-           { name: 'puppetlabs/reboot', version_requirement: '>=2.0.0 < 5.0.0' },
-         ],
-         all_manifests: [],
-       ),
-     ])
+      OpenStruct.new(
+        name: 'mysql',
+        slug: 'puppetlabs-mysql',
+        version: '11.0.1',
+        forge_module?: true,
+        dependencies: [
+          { name: 'puppetlabs/stdlib', version_requirement: '>= 3.2.0 < 8.0.0' },
+          { name: 'puppetlabs/resource_api', version_requirement: '>= 1.0.0 < 2.0.0' },
+        ],
+        all_manifests: [],
+      ),
+      OpenStruct.new(
+        name: 'apache',
+        slug: 'puppetlabs-apache',
+        version: '6.0.0',
+        forge_module?: true,
+        dependencies: [
+          { name: 'puppetlabs/stdlib', version_requirement: '>= 4.13.1 < 8.0.0' },
+          { name: 'puppetlabs/concat', version_requirement: '>= 2.2.1 < 8.0.0' },
+        ],
+        all_manifests: [],
+      ),
+      OpenStruct.new(
+        name: 'concat',
+        slug: 'puppetlabs-concat',
+        version: '7.0.1',
+        forge_module?: true,
+        dependencies: [{ name: 'puppetlabs/stdlib', version_requirement: '>= 4.13.1 < 8.0.0' }],
+        all_manifests: [],
+      ),
+      OpenStruct.new(
+        name: 'stdlib',
+        slug: 'puppetlabs-stdlib',
+        version: '7.0.1',
+        forge_module?: true,
+        dependencies: [],
+        all_manifests: ['/etc/puppetlabs/code/environments/production/modules/stdlib/manifests/init.pp'],
+      ),
+      OpenStruct.new(
+        name: 'my_private_module',
+        slug: 'my_private_module',
+        version: '4.1.0',
+        forge_module?: false,
+        dependencies: [
+          { name: 'private_module_1', version_requirement: '>= 4.24.0 < 8.0.0' },
+          { name: 'private_module_2', version_requirement: '>= 4.4.1 < 9.0.0' },
+          { name: 'puppetlabs/powershell', version_requirement: '>= 2.1.4 < 6.0.0' },
+          { name: 'puppetlabs/reboot', version_requirement: '>=2.0.0 < 5.0.0' },
+        ],
+        all_manifests: [],
+      ),
+    ])
   end
 end
 

--- a/spec/support/examples/platforms.rb
+++ b/spec/support/examples/platforms.rb
@@ -48,19 +48,19 @@ RSpec.shared_examples 'platforms_spec' do |plugin, plugin_name|
       ],
     )
     expect(plugin.run(puppetdb_session)).to eq([
-                                                 class_platforms: [
-                                                   {
-                                                     count: 1,
-                                                     name: 'ModuleA::Foo',
-                                                     platform: 'linux',
-                                                   },
-                                                   {
-                                                     count: 1,
-                                                     name: 'ModuleB::Bar',
-                                                     platform: 'windows',
-                                                   },
-                                                 ],
-                                               ])
+      class_platforms: [
+        {
+          count: 1,
+          name: 'ModuleA::Foo',
+          platform: 'linux',
+        },
+        {
+          count: 1,
+          name: 'ModuleB::Bar',
+          platform: 'windows',
+        },
+      ],
+    ])
   end
 
   it 'generates an example' do

--- a/spec/unit/dropsonde/cache_spec.rb
+++ b/spec/unit/dropsonde/cache_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe Dropsonde::Cache do
     dropsonde_cache.autoupdate
   end
 
-  it 'will autoupdate after ttl has expired' do
+  it 'autoupdates after ttl has expired' do
     cache = {
       'timestamp' => '2000-1-1', # long before any puppet modules were released!
       'modules' => %w[a b c],
@@ -50,7 +50,7 @@ RSpec.describe Dropsonde::Cache do
 
     expect(File).to receive(:file?).with(%r{foo/forge.json}).and_return(true)
     expect(File).to receive(:read).with(%r{foo/forge.json}).and_return(cache.to_json)
-    expect(File).to receive(:mtime).with(%r{foo/forge.json}).and_return((Date.today - 8))
+    expect(File).to receive(:mtime).with(%r{foo/forge.json}).and_return(Date.today - 8)
 
     expect(File).to receive(:file?).with(%r{foo/forge.json}).and_return(true)
     expect(dropsonde_cache).to receive(:update).and_return(true)


### PR DESCRIPTION
I'm not sure how this ever worked to begin with. This just replaces a
weirdly complex attempt to mock out certain method invocations by just
returning an object that behaves how we expect environments to behave in
this context.
