### PR TITLE
CI: configure token permissions

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -4,6 +4,9 @@ on:
   schedule:
     - cron: '0 0 * * *'
 
+permissions:
+  contents: read # minimal permissions that we have to grant
+
 jobs:
   Acceptance:
     name: Acceptance Tests

--- a/.github/workflows/pr_test.yml
+++ b/.github/workflows/pr_test.yml
@@ -2,6 +2,9 @@ name: "PR Testing"
 
 on: [pull_request]
 
+permissions:
+  contents: read # minimal permissions that we have to grant
+
 jobs:
   Acceptance:
     name: Acceptance Tests

--- a/.github/workflows/spec.yml
+++ b/.github/workflows/spec.yml
@@ -4,6 +4,9 @@ on:
   workflow_dispatch:
   pull_request:
 
+permissions:
+  contents: read # minimal permissions that we have to grant
+
 jobs:
   Spec:
     name: "Spec Tests (Ruby: ${{matrix.ruby_version}})"


### PR DESCRIPTION
This will allow us to set the default GITHUB_TOKEN to read-only and not write permissions.